### PR TITLE
Fix request-body description for POST /search/by-aeid/ (AEIDs, not DTXSIDs)

### DIFF
--- a/src/main/java/gov/epa/ccte/api/bioactivity/web/rest/AssayApi.java
+++ b/src/main/java/gov/epa/ccte/api/bioactivity/web/rest/AssayApi.java
@@ -94,7 +94,7 @@ public interface AssayApi {
     })
     @PostMapping(value = "/search/by-aeid/")
     @ResponseBody
-    List<AssayAll> batchSearchAssayByAeid(@io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of DSSTox Substance Identifiers",
+    List<AssayAll> batchSearchAssayByAeid(@io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of ToxCast assay component endpoint IDs (AEIDs)",
             content = {@Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
                     examples = {@ExampleObject("\"[\\\"111\\\",\\\"3032\\\"]\"")})})
                                                     @RequestBody String[] aeids);


### PR DESCRIPTION
## Description

The batch by-AEID assay search (`POST /bioactivity/assay/search/by-aeid/`) describes its request body as a "JSON array of DSSTox Substance Identifiers", but the endpoint takes AEIDs: the parameter is `String[] aeids` and the example is `["111","3032"]`. This updates the description to "JSON array of ToxCast assay component endpoint IDs (AEIDs)", matching the endpoint and the sibling by-AEID descriptions.

Closes #174